### PR TITLE
Small edit. (Fix: HTTP requests on HTTPS port)

### DIFF
--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -61,6 +61,7 @@ http {
 	server {
 		listen        1471;
 		server_name  pineapple;	# Change this, reference -> http://nginx.org/en/docs/http/server_names.html
+		error_page 497 https://$host:$server_port$request_uri;
 		error_page 404 =200 /index.php;
 		error_log /dev/null;
 		access_log /dev/null;


### PR DESCRIPTION
This will forward all HTTP requests on the HTTPS port to the correct place.
This will fix the annoying error msg. you get when going to http://172.16.42.1:1471 after having enabled SSL.

I was a bit unsure about the variable i'm using. ($host)
The safest alternative would be $server_name, which it retrieves from the CN on the cert., but not everyone manually edits their config, and renames their pineapple.... So i landed on $host.